### PR TITLE
Fix check-code-regeneration CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,11 @@ on:
     branches: ["main"]
   pull_request:
     branches: ["**"]
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
 
 permissions:
   contents: "read"
@@ -12,6 +17,7 @@ permissions:
 jobs:
   check-code-regeneration:
     runs-on: ubuntu-latest
+    if: ${{ !github.event.pull_request.draft }}
     steps:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
 
@@ -19,8 +25,13 @@ jobs:
         uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
         with:
           go-version: 1.21
+      
+      - name: Install gen dependencies
+        run: |
+          go install github.com/mailru/easyjson/...@latest
+          go install github.com/hashicorp/copywrite@latest
 
-      - name: Ensure the code has been properly regenerated with 'make regen'
+      - name: Ensure the code has been properly regenerated with 'go generate ./...'
         run: |
           go generate ./...
           readonly changed_files="$(git diff --stat)"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,26 +10,30 @@ permissions:
   packages: "write"
 
 jobs:
-  check-copywrite:
+  check-code-regeneration:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
 
-      - name: Setup Copywrite
-        uses: hashicorp/setup-copywrite@3ace06ad72e6ec679ea8572457b17dbc3960b8ce # v1.0.0
-
-      - name: Check Header Compliance
-        run: copywrite headers
-
-      - name: Ensure the code has been properly regenerated with 'make regen'
+      - name: Set up go
+        uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
+        with:
+          go-version: 1.21
+      
+      - name: Install gen dependencies
         run: |
-          make regen
+          go install github.com/mailru/easyjson/...@latest
+          go install github.com/hashicorp/copywrite@latest
+
+      - name: Ensure the code has been properly regenerated with 'go generate ./...'
+        run: |
+          go generate ./...
           readonly changed_files="$(git diff --stat)"
           if [[ "${changed_files}" != "" ]]; then
-              echo "Found differences in copywrite headers after running 'copywrite headers'"
-              echo "Please run 'copywrite headers' & commit the changed files:"
-              echo "${changed_files}"
-              exit 1
+          echo "Found differences after running 'go generate ./...'"
+          echo "Please run 'go generate ./...' & commit the changed files:"
+          echo "${changed_files}"
+          exit 1
           fi
 
   goreleaser:

--- a/docs/cli/omlox.md
+++ b/docs/cli/omlox.md
@@ -23,7 +23,7 @@ Environment variables:
 ### Options
 
 ```
-      --addr string   omlox hub API endpoint (default "https://staging-whereis.local.wavesys.pt/api/omlox/v2")
+      --addr string   omlox hub API endpoint (default "localhost:8081")
       --debug         enable debug logging
   -h, --help          help for omlox
 ```

--- a/docs/cli/omlox_create.md
+++ b/docs/cli/omlox_create.md
@@ -11,7 +11,7 @@ Create hub resources
 ### Options inherited from parent commands
 
 ```
-      --addr string   omlox hub API endpoint (default "https://staging-whereis.local.wavesys.pt/api/omlox/v2")
+      --addr string   omlox hub API endpoint (default "localhost:8081")
       --debug         enable debug logging
 ```
 

--- a/docs/cli/omlox_create_providers.md
+++ b/docs/cli/omlox_create_providers.md
@@ -22,7 +22,7 @@ omlox create providers [flags]
 ### Options inherited from parent commands
 
 ```
-      --addr string   omlox hub API endpoint (default "https://staging-whereis.local.wavesys.pt/api/omlox/v2")
+      --addr string   omlox hub API endpoint (default "localhost:8081")
       --debug         enable debug logging
 ```
 

--- a/docs/cli/omlox_create_trackables.md
+++ b/docs/cli/omlox_create_trackables.md
@@ -22,7 +22,7 @@ omlox create trackables [flags]
 ### Options inherited from parent commands
 
 ```
-      --addr string   omlox hub API endpoint (default "https://staging-whereis.local.wavesys.pt/api/omlox/v2")
+      --addr string   omlox hub API endpoint (default "localhost:8081")
       --debug         enable debug logging
 ```
 

--- a/docs/cli/omlox_delete.md
+++ b/docs/cli/omlox_delete.md
@@ -11,7 +11,7 @@ Delete hub resources
 ### Options inherited from parent commands
 
 ```
-      --addr string   omlox hub API endpoint (default "https://staging-whereis.local.wavesys.pt/api/omlox/v2")
+      --addr string   omlox hub API endpoint (default "localhost:8081")
       --debug         enable debug logging
 ```
 

--- a/docs/cli/omlox_delete_providers.md
+++ b/docs/cli/omlox_delete_providers.md
@@ -23,7 +23,7 @@ omlox delete providers [flags]
 ### Options inherited from parent commands
 
 ```
-      --addr string   omlox hub API endpoint (default "https://staging-whereis.local.wavesys.pt/api/omlox/v2")
+      --addr string   omlox hub API endpoint (default "localhost:8081")
       --debug         enable debug logging
 ```
 

--- a/docs/cli/omlox_delete_trackables.md
+++ b/docs/cli/omlox_delete_trackables.md
@@ -23,7 +23,7 @@ omlox delete trackables [flags]
 ### Options inherited from parent commands
 
 ```
-      --addr string   omlox hub API endpoint (default "https://staging-whereis.local.wavesys.pt/api/omlox/v2")
+      --addr string   omlox hub API endpoint (default "localhost:8081")
       --debug         enable debug logging
 ```
 

--- a/docs/cli/omlox_gen.md
+++ b/docs/cli/omlox_gen.md
@@ -11,7 +11,7 @@ Generate commands
 ### Options inherited from parent commands
 
 ```
-      --addr string   omlox hub API endpoint (default "https://staging-whereis.local.wavesys.pt/api/omlox/v2")
+      --addr string   omlox hub API endpoint (default "localhost:8081")
       --debug         enable debug logging
 ```
 

--- a/docs/cli/omlox_gen_docs.md
+++ b/docs/cli/omlox_gen_docs.md
@@ -9,7 +9,7 @@ omlox gen docs [flags]
 ### Options
 
 ```
-      --format string   Docs format. One of: [rest markdown yaml]. (default "markdown")
+      --format string   Docs format. One of: [markdown yaml rest]. (default "markdown")
   -h, --help            help for docs
   -o, --output string   Output directory. (default ".")
 ```
@@ -17,7 +17,7 @@ omlox gen docs [flags]
 ### Options inherited from parent commands
 
 ```
-      --addr string   omlox hub API endpoint (default "https://staging-whereis.local.wavesys.pt/api/omlox/v2")
+      --addr string   omlox hub API endpoint (default "localhost:8081")
       --debug         enable debug logging
 ```
 

--- a/docs/cli/omlox_get.md
+++ b/docs/cli/omlox_get.md
@@ -11,7 +11,7 @@ Get hub resources
 ### Options inherited from parent commands
 
 ```
-      --addr string   omlox hub API endpoint (default "https://staging-whereis.local.wavesys.pt/api/omlox/v2")
+      --addr string   omlox hub API endpoint (default "localhost:8081")
       --debug         enable debug logging
 ```
 

--- a/docs/cli/omlox_get_providers.md
+++ b/docs/cli/omlox_get_providers.md
@@ -22,7 +22,7 @@ omlox get providers [flags]
 ### Options inherited from parent commands
 
 ```
-      --addr string   omlox hub API endpoint (default "https://staging-whereis.local.wavesys.pt/api/omlox/v2")
+      --addr string   omlox hub API endpoint (default "localhost:8081")
       --debug         enable debug logging
 ```
 

--- a/docs/cli/omlox_get_trackables.md
+++ b/docs/cli/omlox_get_trackables.md
@@ -22,7 +22,7 @@ omlox get trackables [flags]
 ### Options inherited from parent commands
 
 ```
-      --addr string   omlox hub API endpoint (default "https://staging-whereis.local.wavesys.pt/api/omlox/v2")
+      --addr string   omlox hub API endpoint (default "localhost:8081")
       --debug         enable debug logging
 ```
 

--- a/docs/cli/omlox_subscribe.md
+++ b/docs/cli/omlox_subscribe.md
@@ -32,7 +32,7 @@ omlox subscribe [flags]
 ### Options inherited from parent commands
 
 ```
-      --addr string   omlox hub API endpoint (default "https://staging-whereis.local.wavesys.pt/api/omlox/v2")
+      --addr string   omlox hub API endpoint (default "localhost:8081")
       --debug         enable debug logging
 ```
 

--- a/docs/cli/omlox_version.md
+++ b/docs/cli/omlox_version.md
@@ -15,7 +15,7 @@ omlox version [flags]
 ### Options inherited from parent commands
 
 ```
-      --addr string   omlox hub API endpoint (default "https://staging-whereis.local.wavesys.pt/api/omlox/v2")
+      --addr string   omlox hub API endpoint (default "localhost:8081")
       --debug         enable debug logging
 ```
 

--- a/flake.nix
+++ b/flake.nix
@@ -6,19 +6,40 @@
     flake-utils.url = "github:numtide/flake-utils";
   };
 
-  outputs = { self, nixpkgs, flake-utils, ... }:
+  outputs =
+    {
+      self,
+      nixpkgs,
+      flake-utils,
+      ...
+    }:
     flake-utils.lib.eachDefaultSystem (
       system:
       let
-        pkgs = nixpkgs.legacyPackages.${system};
-        buildDeps = with pkgs; [ git go_1_21 gnumake ];
-        devDeps = with pkgs;
-          buildDeps ++ [
+        overlay = import ./nix/pkgs;
+
+        pkgs = import nixpkgs {
+          inherit system;
+          overlays = [ overlay ];
+        };
+
+        buildDeps = with pkgs; [
+          git
+          go_1_21
+          gnumake
+        ];
+
+        devDeps =
+          with pkgs;
+          buildDeps
+          ++ [
             easyjson
             goreleaser
+            copywrite
           ];
       in
-      { devShell = pkgs.mkShell { buildInputs = devDeps; }; }
+      {
+        devShell = pkgs.mkShell { buildInputs = devDeps; };
+      }
     );
-
 }

--- a/nix/pkgs/copywrite.nix
+++ b/nix/pkgs/copywrite.nix
@@ -1,0 +1,56 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  installShellFiles,
+  testers,
+  copywrite,
+}:
+
+buildGoModule rec {
+  pname = "copywrite";
+  version = "0.19.0";
+
+  src = fetchFromGitHub {
+    owner = "hashicorp";
+    repo = "copywrite";
+    rev = "6ed520a710166c6094098b786c63f212604654a4"; # matches tag release
+    hash = "sha256-DmlPioaw/wMk8GoBYNG24P4J1C6h0bjVjjOuMYW6Tgo=";
+  };
+
+  vendorHash = "sha256-ZIu0/fue3xi+YVE9GFsVjCNs8t3c3TWH8O0xUzJdim8=";
+
+  shortRev = builtins.substring 0 7 src.rev;
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/hashicorp/copywrite/cmd.version=${version}"
+    "-X github.com/hashicorp/copywrite/cmd.commit=${shortRev}"
+  ];
+
+  CGO_ENABLED = 0;
+
+  nativeBuildInputs = [ installShellFiles ];
+  postInstall = ''
+    $out/bin/copywrite completion bash > copywrite.bash
+    $out/bin/copywrite completion zsh > copywrite.zsh
+    $out/bin/copywrite completion fish > copywrite.fish
+    installShellCompletion copywrite.{bash,zsh,fish}
+  '';
+
+  passthru.tests.version = testers.testVersion {
+    package = copywrite;
+    command = "copywrite --version";
+    version = "${version}-${shortRev}";
+  };
+
+  meta = {
+    description = "Automate copyright headers and license files at scale";
+    mainProgram = "copywrite";
+    homepage = "https://github.com/hashicorp/copywrite";
+    changelog = "https://github.com/hashicorp/copywrite/releases/tag/v${version}";
+    license = lib.licenses.mpl20;
+    maintainers = with lib.maintainers; [ dvcorreia ];
+  };
+}

--- a/nix/pkgs/default.nix
+++ b/nix/pkgs/default.nix
@@ -1,0 +1,3 @@
+final: prev: {
+  copywrite = final.callPackage ./copywrite.nix { };
+}


### PR DESCRIPTION
Some dependencies were missing during the `check-code-regeneration` job in the GitHub Action, so they were added: `easyjson` and `copywrite`.
For the CI to pass, the docs for the `omlox-cli` had to be re-generated, since they were out of date.
`copywrite` was also added the nix development shell since it was missing it.