### PR TITLE
Update maintainer's email

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,1 +1,1 @@
-Diogo Correia <dcorreia@wavecom.pt, dv_correia@hotmail.com> (@dvcorreia)
+Diogo Correia <dv_correia@hotmail.com> (@dvcorreia)


### PR DESCRIPTION
Email `dcorreia@wavecom.pt` is not longer active so it should be removed.