### PR TITLE
fix nix package vendor hash

### DIFF
--- a/package.nix
+++ b/package.nix
@@ -11,7 +11,7 @@ buildGoModule (finalAttrs: {
 
   src = ./.;
 
-  vendorHash = "sha256-Gwkse7dl/EYxHSibgc6PMGwtDhKiMJYFajwAICpluzw=";
+  vendorHash = "sha256-8pNpJ9brmL88CVbh9vlm/Cd4QSstZTIWYn5nFqfe2Xw=";
 
   ldflags = [
     "-s"

--- a/package.nix
+++ b/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   buildGoModule,
-  version ? 0.0.0,
+  version ? "0.0.0",
   commitHash ? "unknown",
 }:
 


### PR DESCRIPTION
Some dependency update seems to have been applied, so the vendor hash is wrong and the package doesn't build. This updates the hash to a correct one and fixes the default version string, which should be a string.