### PR TITLE
ci: use nix dependencies in ci jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,9 +22,7 @@ jobs:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
 
       - name: Install Nix
-        uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
-        with:
-          nix_path: nixpkgs=channel:nixos-unstable
+        uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
 
       - name: Regenerate code
         run: nix develop -c go generate ./...
@@ -45,9 +43,7 @@ jobs:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
 
       - name: Install Nix
-        uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
-        with:
-          nix_path: nixpkgs=channel:nixos-unstable
+        uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
 
       - name: Build
         run: nix develop -c go build -v ./...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,25 +21,22 @@ jobs:
     steps:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
 
-      - name: Set up go
-        uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
+      - name: Install Nix
+        uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
         with:
-          go-version: 1.21
-      
-      - name: Install gen dependencies
-        run: |
-          go install github.com/mailru/easyjson/...@latest
-          go install github.com/hashicorp/copywrite@latest
+          nix_path: nixpkgs=channel:nixos-unstable
 
-      - name: Ensure the code has been properly regenerated with 'go generate ./...'
+      - name: Regenerate code
+        run: nix develop -c go generate ./...
+
+      - name: Ensure the code has been properly regenerated
         run: |
-          go generate ./...
           readonly changed_files="$(git diff --stat)"
           if [[ "${changed_files}" != "" ]]; then
-          echo "Found differences after running 'go generate ./...'"
-          echo "Please run 'go generate ./...' & commit the changed files:"
-          echo "${changed_files}"
-          exit 1
+            echo "Found differences after running 'go generate ./...'"
+            echo "Please run 'go generate ./...' & commit the changed files:"
+            echo "${changed_files}"
+            exit 1
           fi
 
   tests:
@@ -47,15 +44,15 @@ jobs:
     steps:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
 
-      - name: Set up go
-        uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
+      - name: Install Nix
+        uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
         with:
-          go-version: 1.21
+          nix_path: nixpkgs=channel:nixos-unstable
 
       - name: Build
-        run: go build -v ./...
+        run: nix develop -c go build -v ./...
 
       - name: Test
-        run: go test -v ./...
+        run: nix develop -c go test -v ./...
 
   # TODO @dvcorreia: add linting workflow

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Ensure the code has been properly regenerated
         run: |
-          readonly changed_files="$(git diff --stat)"
+          readonly changed_files="$(git status --porcelain)"
           if [[ "${changed_files}" != "" ]]; then
             echo "Found differences after running 'go generate ./...'"
             echo "Please run 'go generate ./...' & commit the changed files:"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,15 +24,13 @@ jobs:
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
 
-      - name: Regenerate code
-        run: nix develop -c go generate ./...
-
-      - name: Ensure the code has been properly regenerated
+      - name: Ensure the code has been properly regenerated with 'nix develop -c go generate ./...'
         run: |
+          nix develop -c go generate ./...
           readonly changed_files="$(git status --porcelain)"
           if [[ "${changed_files}" != "" ]]; then
-            echo "Found differences after running 'go generate ./...'"
-            echo "Please run 'go generate ./...' & commit the changed files:"
+            echo "Found differences after running 'nix develop -c go generate ./...'"
+            echo "Please run 'nix develop -c go generate ./...' & commit the changed files:"
             echo "${changed_files}"
             exit 1
           fi


### PR DESCRIPTION
### Context

The `check-code-regeneration` job was failing because the local development Nix setup was using `go1.24.3` and the job was using the hardcoded `go1.21`. By using Nix dependencies in the ci jobs, problems like these should not occur again

This should close #27 